### PR TITLE
Update VEDA UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@devseed-ui/theme-provider": "^4.1.0",
-    "@teamimpact/veda-ui": "6.6.4",
+    "@teamimpact/veda-ui": "6.10.1",
     "@uswds/uswds": "^3.10.0",
     "geist": "1.2.2",
     "gray-matter": "^4.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2083,10 +2083,10 @@
   resolved "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz#2977727d8fc8dfa079112d9f4d4c019110f1732c"
   integrity sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==
 
-"@teamimpact/veda-ui@6.6.4":
-  version "6.6.4"
-  resolved "https://registry.npmjs.org/@teamimpact/veda-ui/-/veda-ui-6.6.4.tgz#bbb308adc91710152fab365ebe07a3e0d4a806e5"
-  integrity sha512-QioZUaDci2ANm3AE+nwKJ+7SThzGBJto44Q7sU0CFWZINtnmqLCrzQO0Mh/vc9Jmi6hvR7usC9QFsAq2SQSztg==
+"@teamimpact/veda-ui@6.10.1":
+  version "6.10.1"
+  resolved "https://registry.npmjs.org/@teamimpact/veda-ui/-/veda-ui-6.10.1.tgz#34e5aafd75942bf04b27631a1b924bb6e515b849"
+  integrity sha512-CFoCS4QhpFaXk218ICx/YGGPva0BTJ2c0zxjHNrN1DaL3708EBI19EM5U7oja9TM4evAsE4/3DNRnppxRs5YEQ==
   dependencies:
     "@codemirror/lang-markdown" "^6.1.1"
     "@codemirror/state" "^6.2.1"


### PR DESCRIPTION
Updating VEDA UI to include the fix for render extension : https://github.com/NASA-IMPACT/veda-ui/releases/tag/v6.10.1

Nightlight: https://eoviz-workshop-veda-git-f2a7ed-anthony-boyds-projects-24260059.vercel.app/exploration?datasets=%5B%7B%22id%22%3A%22nightlights-hd-monthly%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22mean%22%2C%22label%22%3A%22Average%22%2C%22chartLabel%22%3A%22Average%22%2C%22themeColor%22%3A%22infographicB%22%7D%2C%7B%22id%22%3A%22std%22%2C%22label%22%3A%22St+Deviation%22%2C%22chartLabel%22%3A%22St+Deviation%22%2C%22themeColor%22%3A%22infographicD%22%7D%5D%7D%7D%5D&taxonomy=%7B%7D&search=&date=2022-03-01T05%3A00%3A00.000Z